### PR TITLE
chore(nix): add shell.nix for nodejs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+# the last successful build of nixpkgs-unstable as of 2022-11-21
+with import
+  (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/19230cff31fd7562562dd25181579fa7087f0f89.tar.gz";
+    sha256 = "1ds3rgwqhgrydzzazz5lqi825k38lp8hm62ggh8dfxh6c6b7h3jl";
+  })
+{ };
+
+let
+  nodejs = nodejs-16_x;
+in
+  stdenv.mkDerivation {
+    name = "bleskomat-server-dev";
+    buildInputs = [
+      nodejs
+    ];
+  }


### PR DESCRIPTION
Creating `shell.nix` for nodejs. Probably a step forward would be to add postgress as a database for the server.